### PR TITLE
Update README with deprecation note and fix tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+Note: This project is using a older version of the Tableau Embedding API (v2.0.0, whereas v3.4.X is currently available)
+
+To use a more up-to-date api version you can either:
+* Manually download, copy, and export a version of the tableau API (as this repo's "tableau-api" dependency does). Eg from `https://public.tableau.com/javascripts/api/tableau.embedding.3.latest.js` as per the [Tableau docs](https://help.tableau.com/current/api/embedding_api/en-us/docs/embedding_api_get.html).
+* Use an up-to-date project (such as the [TableauEmbed](https://github.com/stoddabr/react-tableau-embed-live) react component)
+
 # Tableau API
 
 This is a version of the 


### PR DESCRIPTION
Add warning note about the dependency on a deprecated Tableau API and hints for future users to fix it. 

Includes high-level instructions for getting a static copy of the embedding API, and an example of a project that wraps it with dynamic versioning (ie, https://github.com/stoddabr/react-tableau-embed-live)